### PR TITLE
Fix autoinvite trigger not being registered

### DIFF
--- a/ElvUI_KlixUI/modules/misc/invite.lua
+++ b/ElvUI_KlixUI/modules/misc/invite.lua
@@ -45,7 +45,7 @@ function MI:InviteRanks()
     end
 end
 
-function MI:LoadInviteGroup()
-    self:RegisterEvent("CHAT_MSG_WHISPER", AutoInvite)
-    self:RegisterEvent("CHAT_MSG_BN_WHISPER", AutoInvite)
-end
+
+MI:RegisterEvent("CHAT_MSG_WHISPER", AutoInvite)
+MI:RegisterEvent("CHAT_MSG_BN_WHISPER", AutoInvite)
+


### PR DESCRIPTION
MI:LoadInviteGroup() was never evoked.

Tested on my own client with Evlui 1.22, KlixUI 0.09, WoW 1.13.4 (build 33728)