### PR TITLE
Add Arcane Intellect Rank 5 to Mage filter

### DIFF
--- a/ElvUI_KlixUI/defaults/filters/Reminder.lua
+++ b/ElvUI_KlixUI/defaults/filters/Reminder.lua
@@ -26,6 +26,7 @@ KUI.ReminderList = {
 		["Intellect"] = {
 			["spellGroup"] = {
 				[23028] = true,
+				[10157] = true,
 				["defaultIcon"] = 23028, -- Arcane Brilliance
 			},
 			["enable"] = true,


### PR DESCRIPTION
On mages the Arcane Intellect is not registered. The reminder module keeps showing Arcane Brillance while an equivalant (solo) buff is active.