### PR TITLE
Add DT:LoadDataTexts to KUIL:Initialize

### DIFF
--- a/ElvUI_KlixUI/layout/layout.lua
+++ b/ElvUI_KlixUI/layout/layout.lua
@@ -727,6 +727,7 @@ function KUIL:Initialize()
 	hooksecurefunc(DT, 'LoadDataTexts', updateButtonFont)
 	hooksecurefunc(E, 'UpdateMedia', updateButtonFont)
 	self:RegisterEvent('PLAYER_ENTERING_WORLD')
+	DT:LoadDataTexts()
 	--self:RegisterEvent('ACTIVE_TALENT_GROUP_CHANGED', 'regEvents')
 end
 


### PR DESCRIPTION
LoadDataTexts is called before the KlixUI panels are registered therefore panels not being displayed until anything related to the datatexts is changed in the config. Isn't a general problem as on some chars the order of calling was still correct and panels loaded before LoadDataTexts is called by ElvUI. This fixes the issue however :P